### PR TITLE
Blanket Implementation

### DIFF
--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -25,3 +25,16 @@ pub trait TypedContainer {
     /// Returns the [`std::any::TypeId`] of the contained value.
     fn type_id(&self) -> TypeId;
 }
+
+// ------------------------- Blanket Implementations ------------------------- //
+impl<T> TryAsRef<T> for T {
+    fn try_as_ref(&self) -> Option<&T> {
+        Some(self)
+    }
+}
+
+impl<T> TryAsMut<T> for T {
+    fn try_as_mut(&mut self) -> Option<&mut T> {
+        Some(self)
+    }
+}


### PR DESCRIPTION
Had a need to call try_into on other types trivially (returns self). This adds a simple generic blanket implementation for such a case. Similar to the [blanket implementation of From in the std](https://doc.rust-lang.org/src/core/convert/mod.rs.html#765).